### PR TITLE
Get and cast value from HWND

### DIFF
--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -93,7 +93,7 @@ impl crate::Instance<super::Api> for super::Instance {
             raw_window_handle::RawWindowHandle::Win32(handle) => Ok(super::Surface {
                 factory: self.factory.clone(),
                 factory_media: self.factory_media.clone(),
-                target: SurfaceTarget::WndHandle(handle.hwnd as *mut _),
+                target: SurfaceTarget::WndHandle(handle.hwnd.get() as *mut _),
                 supports_allow_tearing: self.supports_allow_tearing,
                 swap_chain: None,
             }),

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -441,7 +441,7 @@ impl crate::Instance<super::Api> for Instance {
             )));
         };
         Ok(Surface {
-            window: window.hwnd as *mut _,
+            window: window.hwnd.get() as *mut _,
             presentable: true,
             swapchain: None,
             srgb_capable: self.srgb_capable,

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -758,7 +758,7 @@ impl crate::Instance<super::Api> for super::Instance {
                 use winapi::um::libloaderapi::GetModuleHandleW;
 
                 let hinstance = unsafe { GetModuleHandleW(std::ptr::null()) };
-                self.create_surface_from_hwnd(hinstance as *mut _, handle.hwnd)
+                self.create_surface_from_hwnd(hinstance as *mut _, handle.hwnd.get() as *mut _)
             }
             #[cfg(target_os = "macos")]
             (Rwh::AppKit(handle), _)


### PR DESCRIPTION
**Checklist**

- [x ] Run `cargo clippy`.
- [ ] Run `cargo clippy --target wasm32-unknown-unknown` if applicable.
- [ ] Add change to CHANGELOG.md. See simple instructions inside file.

**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
`cargo clippy` fails:
```
   --> examples\common\src\framework.rs:572:52
    |
572 | ...                   platform_specific: false,
    |                                          ^^^^^ expected `KeyEventExtra`, found `bool`
```
It looks like this has already been fixed in trunk.
